### PR TITLE
Pass corresponding zero-values of optional params

### DIFF
--- a/apis/compute/v1alpha1/droplet_types.go
+++ b/apis/compute/v1alpha1/droplet_types.go
@@ -54,7 +54,7 @@ type DropletParameters struct {
 	// that you wish to embed in the Droplet's root account upon creation.
 	// +optional
 	// +immutable
-	SSHKeys []int `json:"ssh_keys"`
+	SSHKeys []string `json:"ssh_keys"`
 
 	// Backups: A boolean indicating whether automated backups should be enabled
 	// for the Droplet. Automated backups can only be enabled when the Droplet is

--- a/apis/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/compute/v1alpha1/zz_generated.deepcopy.go
@@ -103,7 +103,7 @@ func (in *DropletParameters) DeepCopyInto(out *DropletParameters) {
 	*out = *in
 	if in.SSHKeys != nil {
 		in, out := &in.SSHKeys, &out.SSHKeys
-		*out = make([]int, len(*in))
+		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
 	if in.Backups != nil {

--- a/package/crds/compute.do.crossplane.io_droplets.yaml
+++ b/package/crds/compute.do.crossplane.io_droplets.yaml
@@ -74,7 +74,7 @@ spec:
                   ssh_keys:
                     description: 'SSHKeys: An array containing the IDs or fingerprints of the SSH keys that you wish to embed in the Droplet''s root account upon creation.'
                     items:
-                      type: integer
+                      type: string
                     type: array
                   tags:
                     description: 'Tags: A flat array of tag names as strings to apply to the Droplet after it is created. Tag names can either be existing or new tags.'

--- a/pkg/clients/digitalocean.go
+++ b/pkg/clients/digitalocean.go
@@ -61,6 +61,24 @@ func GetAuthInfo(ctx context.Context, c client.Client, mg resource.Managed) (tok
 	return string(s.Data[ref.Key]), nil
 }
 
+// StringValue converts the supplied string pointer to a string, returning the
+// empty string if the pointer is nil.
+func StringValue(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+// BoolValue converts the supplied bool pointer to an bool, returning false if
+// the pointer is nil.
+func BoolValue(v *bool) bool {
+	if v == nil {
+		return false
+	}
+	return *v
+}
+
 // LateInitialize functions initialize s(first argument), presumed to be an
 // optional field of a Kubernetes API object's spec per Kubernetes
 // "late initialization" semantics. s is returned unchanged if it is non-nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

If any of the optional `DropletParameters` is empty, `null` is passed to the underlying request to DigitalOcean API which breaks the reconcile loop. Instead we need to default them to corresponding zero values of each type.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

TBA