### PR TITLE
Initial commit of using Tilt for dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ cover.out
 
 # ignore vscode files (debug config etc...)
 /.vscode
+
+# Tilt
+tilt-settings.json
+tild.d/
+tilt_modules/
+cluster/local/provider.Tiltfile

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ run:
 
   skip-files:
   - "zz_generated\\..+\\.go$"
+  - "tilt_modules"
 
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,79 @@
+# Tilt >= v0.17.8 is required to handle escaping of colons in selector names and proper
+# teardown of resources
+load('ext://min_tilt_version', 'min_tilt_version')
+min_tilt_version('0.17.8')
+
+# We require at minimum CRD support, so need at least Kubernetes v1.16
+load('ext://min_k8s_version', 'min_k8s_version')
+min_k8s_version('1.16')
+
+# Load the provider helpers
+local_file = 'cluster/local/provider.Tiltfile'
+if os.path.exists(local_file) == False:
+    # TODO(khos2ow): change this URL when corresponding
+    # PR in crossplane/crossplane gets merged.
+    #
+    # https://github.com/crossplane/crossplane/pull/1925
+    remote_file = 'https://raw.githubusercontent.com/khos2ow/crossplane/tilt/cluster/local/provider.Tiltfile'
+    local('curl -sSLo ' + local_file + ' ' + remote_file)
+
+symbols = load_dynamic(local_file)
+build_provider = symbols['build_provider']
+deploy_provider = symbols['deploy_provider']
+
+####################################################################################
+# Crossplane Provider
+####################################################################################
+def build_deploy_providers():
+    settings = {
+        'args': [],
+        'debug': False,
+        'namespace': 'crossplane-system'
+    }
+    settings.update(read_json(
+        "tilt-settings.json",
+        default = {}
+    ))
+
+    # Make sure these value are set as follow (they are needed like this)
+    settings['core_path'] = os.getcwd()
+    settings['resource_deps'] = []
+    settings['local_image'] = True
+
+    name = 'provider-digitalocean'
+    provider = {
+        'short_name': 'digitalocean',
+        'context': os.getcwd(),
+        'go_main': './cmd/provider',
+        'cmd_deps': [
+            'go.mod',
+            'go.sum',
+            'apis',
+            'cmd',
+            'pkg'
+        ],
+        'crd_deps': [
+            'apis'
+        ],
+        'crds_folder': 'package/crds',
+        'package_name': 'khos2ow/provider-digitalocean:master',
+        'image_name': 'khos2ow/provider-digitalocean-controller'
+    }
+
+    build_provider(name, provider, settings)
+    deploy_provider(name, provider, settings)
+
+build_deploy_providers()
+
+####################################################################################
+# Custom Tiltfiles
+#
+# Users may define their own Tilt customizations in tilt.d.
+# This directory is excluded from git and these files will
+# not be checked in to version control.
+####################################################################################
+def include_custom_files():
+    for f in listdir("tilt.d"):
+        include(f)
+
+include_custom_files()


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR introduces usage of [Tilt](https://github.com/tilt-dev/tilt). Using Tilt will significantly improve developer's experience while working on Crossplane provider. The workflow will be as follow:

- spin up a local cluster (using new [`kind-with-registry.sh`](https://github.com/tilt-dev/kind-local/blob/master/kind-with-registry.sh) is recommended)
- `kubectl create ns crossplane-system`
- `helm upgrade --devel --install crossplane --namespace crossplane-system crossplane-master/crossplane`
- `tilt up` from root of the repository
    
Tilt will watch the changes in required folders (e.g. `cmd`, `pkg`, ...) and ignore the rest (e.g. `docs`, `hacks`, ...) and build and live-reload the resources needed to be deployed. Note that it will also watch `apis` folder and regenerates CRDs as well.

You can use a `gitignore`-d file `tilt-settings.json` to control some behavior for the development environment:

`tilt-settings.json`:

```txt
{
    "args": [],                             // pass additional args to provider pod
    "debug": false,                         // enable debugging for provider pod
    "namespace": "crossplane-system"        // use another namespace to deploy provider into
}
```

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

n/a